### PR TITLE
feat: implement `getRunTime` and zero all clocks at the start of a solve

### DIFF
--- a/packages/highs-addon/index.d.ts
+++ b/packages/highs-addon/index.d.ts
@@ -7,7 +7,6 @@ export declare class Solver {
   setOption(name: string, val: OptionValue): void;
   getOption<N extends keyof TypedOptions>(name: N): TypedOptions[N];
   getOption(name: string): OptionValue;
-  zeroAllClocks(): void;
   getRunTime(): number;
 
   passModel(model: Model): void;

--- a/packages/highs-addon/index.d.ts
+++ b/packages/highs-addon/index.d.ts
@@ -7,7 +7,6 @@ export declare class Solver {
   setOption(name: string, val: OptionValue): void;
   getOption<N extends keyof TypedOptions>(name: N): TypedOptions[N];
   getOption(name: string): OptionValue;
-  getRunTime(): number;
 
   passModel(model: Model): void;
   readModel(fp: string, cb: (err: Error) => void): string;
@@ -26,6 +25,7 @@ export declare class Solver {
   run(cb: (err: Error) => void): void;
   getModelStatus(): ModelStatus;
   getInfo(): Info;
+  getRunTime(): number;
 
   getSolution(): Solution;
   setSolution(

--- a/packages/highs-addon/index.d.ts
+++ b/packages/highs-addon/index.d.ts
@@ -7,6 +7,8 @@ export declare class Solver {
   setOption(name: string, val: OptionValue): void;
   getOption<N extends keyof TypedOptions>(name: N): TypedOptions[N];
   getOption(name: string): OptionValue;
+  zeroAllClocks(): void;
+  getRunTime(): number;
 
   passModel(model: Model): void;
   readModel(fp: string, cb: (err: Error) => void): string;

--- a/packages/highs-addon/src/solver.cc
+++ b/packages/highs-addon/src/solver.cc
@@ -434,12 +434,11 @@ Napi::Value Solver::GetInfo(const Napi::CallbackInfo& info) {
 Napi::Value Solver::GetRunTime(const Napi::CallbackInfo &info) {
   Napi::Env env = info.Env();
   int length = info.Length();
-  if (length != 0)
-  {
+  if (length != 0) {
     ThrowTypeError(env, "Expected 0 arguments");
     return env.Undefined();
   }
-  return Napi::Number::New(env, (double)this->highs_->getRunTime());
+  return Napi::Number::New(env, (double) this->highs_->getRunTime());
 }
 
 // Solutions

--- a/packages/highs-addon/src/solver.cc
+++ b/packages/highs-addon/src/solver.cc
@@ -19,7 +19,8 @@ void Solver::Init(Napi::Env env, Napi::Object exports) {
                    InstanceMethod("run", &Solver::Run),
                    InstanceMethod("getModelStatus", &Solver::GetModelStatus),
                    InstanceMethod("getInfo", &Solver::GetInfo),
-
+                   InstanceMethod("getRunTime", &Solver::GetRunTime),
+                   
                    InstanceMethod("getSolution", &Solver::GetSolution),
                    InstanceMethod("setSolution", &Solver::SetSolution),
                    InstanceMethod("writeSolution", &Solver::WriteSolution),
@@ -27,7 +28,9 @@ void Solver::Init(Napi::Env env, Napi::Object exports) {
 
                    InstanceMethod("clearModel", &Solver::ClearModel),
                    InstanceMethod("clearSolver", &Solver::ClearSolver),
-                   InstanceMethod("clear", &Solver::Clear)});
+                   InstanceMethod("clear", &Solver::Clear),
+
+                   InstanceMethod("zeroAllClocks", &Solver::ZeroAllClocks)});
 
   Napi::FunctionReference* constructor = new Napi::FunctionReference();
   *constructor = Napi::Persistent(func);
@@ -428,6 +431,17 @@ Napi::Value Solver::GetInfo(const Napi::CallbackInfo& info) {
   return obj;
 }
 
+Napi::Value Solver::GetRunTime(const Napi::CallbackInfo &info) {
+  Napi::Env env = info.Env();
+  int length = info.Length();
+  if (length != 0)
+  {
+    ThrowTypeError(env, "Expected 0 arguments");
+    return env.Undefined();
+  }
+  return Napi::Number::New(env, (double)this->highs_->getRunTime());
+}
+
 // Solutions
 
 Napi::Value ToFloat64Array(const Napi::Env& env, const std::vector<double>& vec) {
@@ -568,4 +582,14 @@ void Solver::ClearSolver(const Napi::CallbackInfo& info) {
     ThrowError(env, "Clear solver failed");
     return;
   }
+}
+
+void Solver::ZeroAllClocks(const Napi::CallbackInfo &info) {
+  Napi::Env env = info.Env();
+  int length = info.Length();
+  if (length != 0) {
+    ThrowTypeError(env, "Expected 0 arguments");
+    return;
+  }
+  this->highs_->zeroAllClocks();
 }

--- a/packages/highs-addon/src/solver.h
+++ b/packages/highs-addon/src/solver.h
@@ -24,6 +24,7 @@ class Solver : public Napi::ObjectWrap<Solver> {
   void Run(const Napi::CallbackInfo& info);
   Napi::Value GetModelStatus(const Napi::CallbackInfo& info);
   Napi::Value GetInfo(const Napi::CallbackInfo& info);
+  Napi::Value GetRunTime(const Napi::CallbackInfo &info);
 
   Napi::Value GetSolution(const Napi::CallbackInfo& info);
   void SetSolution(const Napi::CallbackInfo& info);
@@ -33,6 +34,8 @@ class Solver : public Napi::ObjectWrap<Solver> {
   void Clear(const Napi::CallbackInfo& info);
   void ClearModel(const Napi::CallbackInfo& info);
   void ClearSolver(const Napi::CallbackInfo& info);
+
+  void ZeroAllClocks(const Napi::CallbackInfo &info);
 
   std::shared_ptr<Highs> highs_;
 };

--- a/packages/highs-solver/src/solver.ts
+++ b/packages/highs-solver/src/solver.ts
@@ -270,6 +270,8 @@ export class Solver {
     const {telemetry: tel} = this;
     tel.logger.debug('Starting solve...');
 
+    this.delegated('zeroAllClocks');
+
     let logPath = this.delegated('getOption', 'log_file');
     assertType('string', logPath);
 
@@ -332,6 +334,11 @@ export class Solver {
   /** Returns true if the solver is currently solving the model. */
   isSolving(): boolean {
     return this.solving;
+  }
+
+  /** Returns the cumulative wall-clock time spent in the last solve */
+  getRunTime(): number {
+    return this.delegated('getRunTime');
   }
 
   /** Returns the current solver status, set from the last solve. */


### PR DESCRIPTION
Solves the issue with ever-increasing solver time, which eventually leads to `TIME_LIMIT` as explained in https://github.com/jump-dev/HiGHS.jl/issues/167